### PR TITLE
:wrench: copy시 windowSelection이용 처리.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         const cb = new ClipboardJS(elTextArea);
         elTextArea.addEventListener('copy', function (e) {
             e.preventDefault();
-            cb.copy(e, 'testData');
+            cb.copy(e);
         });
 
         elTextArea.addEventListener('paste', function (e) {

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -6,7 +6,7 @@ class Clipboard {
     };
     elClipboard: any;
     targetElement: any;
-    constructor(element: any) {
+    constructor() {
         this.browser = {
             isChrome: false,
             isMSEdge: false,
@@ -21,8 +21,9 @@ class Clipboard {
         this.__createClipboardElement__();
     }
 
-    copy(e: any, text: string) {
-        console.log('copy event is called!', text);
+    copy(e: any) {
+        console.log('copy event is called!');
+        const text = window.getSelection().toString();
         if (this.browser.isChrome) { // clipboardData에 접근 가능 할 때.
             e.clipboardData.setData('text/plain', text);
             e.clipboardData.setData('text/html', text);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./dist/",
         "sourceMap": true,
-        "strict": true,
+        "strict": false,
         "noImplicitReturns": true,
         "noImplicitAny": true,
         "module": "es6",


### PR DESCRIPTION
### 이슈 내용
복사시 사용자가 copy할 text를 넘겨주는게아닌 window.getSelection을 이용하여 셀렉션된 텍스트를 꺼내와서 클립보드에 저장하도록 처리.
### 해결 방법
window.getSelection().toString()을하면 현재 셀렉션에서 데이터를 가져 올 수 있음.
* resolved #10 