### PR TITLE
:tada: IE이벤트처리 시작.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### What is CrossBrowserClipboard?
 
-If you use editor that is not contentEditable. You can get Data from Clipboard or set Data to Clipboard By CrossBrowserClipboard.
+If you use editor that is not contentEditable Element like textArea. You can get Data from Clipboard or set Data to Clipboard By CrossBrowserClipboard.
 
 ### Copy to clipboard for the Web
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### What is CrossBrowserClipboard?
+
+If you use editor that is not contentEditable. You can get Data from Clipboard or set Data to Clipboard By CrossBrowserClipboard.
+
 ### Copy to clipboard for the Web
 
 ### Paste to web for the clipboard
@@ -13,26 +17,8 @@ npm install ***
 <script src='./dist/clipboard.js'></script>
 ~~~
 ~~~javascript
-const cb = new ClipboardJS(elTextArea);
-elTextArea.addEventListener('copy', function (e) {
-    e.preventDefault();
-    cb.copy(e);
-});
-
-elTextArea.addEventListener('paste', function (e) {
-    e.preventDefault();
-    const text = cb.paste();
-});
-
-elTextArea.addEventListener('beforecopy', function (e) {
-    e.preventDefault();
-    cb.copy(e);
-});
-
-elTextArea.addEventListener('beforepaste', function (e) {
-    e.preventDefault();
-    const text = cb.paste();
-});
+const elTextArea = document.getElementById('textArea');
+new ClipboardJS(elTextArea);
 ~~~
 
 ### API

--- a/README.md
+++ b/README.md
@@ -16,16 +16,26 @@ npm install ***
 const cb = new ClipboardJS(elTextArea);
 elTextArea.addEventListener('copy', function (e) {
     e.preventDefault();
-    const text = ''; // 클립보드에 넣을 데이터.
-    cb.copy(e, text);
+    cb.copy(e);
 });
 
 elTextArea.addEventListener('paste', function (e) {
     e.preventDefault();
     const text = cb.paste();
 });
-        
+
+elTextArea.addEventListener('beforecopy', function (e) {
+    e.preventDefault();
+    cb.copy(e);
+});
+
+elTextArea.addEventListener('beforepaste', function (e) {
+    e.preventDefault();
+    const text = cb.paste();
+});
 ~~~
 
 ### API
+copy
 
+paste

--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
 </head>
 
 <body onload=initCB();>
-    <div contenteditable=true id="textArea" style="width: 200px; height: 100px; border: solid 1px black"></div>
+    <textarea contenteditable=true id="textArea"
+        style="width: 200px; height: 100px; border: solid 1px black"></textarea>
 </body>
 <script>
     function initCB() {

--- a/index.html
+++ b/index.html
@@ -9,11 +9,6 @@
 
 <body onload=initCB();>
     <div contenteditable=true id="textArea" style="width: 200px; height: 100px; border: solid 1px black"></div>
-
-    <!-- <div style="width: 300px; height: 100px; margin-top: 50px;">
-        <label>클립보드</label>
-        <div id="clipboard" style="width: 200px; height: 100px; border: solid 1px orange"></div>
-    </div> -->
 </body>
 <script>
     function initCB() {

--- a/index.html
+++ b/index.html
@@ -8,17 +8,17 @@
 </head>
 
 <body onload=initCB();>
-    <textarea id="textArea" style="width: 200px; height: 100px; border: solid 1px black"></textarea>
+    <div contenteditable=true id="textArea" style="width: 200px; height: 100px; border: solid 1px black"></div>
 
-    <div style="width: 300px; height: 100px; margin-top: 50px;">
+    <!-- <div style="width: 300px; height: 100px; margin-top: 50px;">
         <label>클립보드</label>
         <div id="clipboard" style="width: 200px; height: 100px; border: solid 1px orange"></div>
-    </div>
+    </div> -->
 </body>
 <script>
     function initCB() {
-        const elTextArea = document.getElementById('textArea');
-        new ClipboardJS(elTextArea);
+        var elTextArea = document.getElementById('textArea');
+        var cb = new ClipboardJS(elTextArea);
     }
 </script>
 

--- a/index.html
+++ b/index.html
@@ -18,16 +18,7 @@
 <script>
     function initCB() {
         const elTextArea = document.getElementById('textArea');
-        const cb = new ClipboardJS(elTextArea);
-        elTextArea.addEventListener('copy', function (e) {
-            e.preventDefault();
-            cb.copy(e);
-        });
-
-        elTextArea.addEventListener('paste', function (e) {
-            e.preventDefault();
-            cb.paste(e);
-        });
+        new ClipboardJS(elTextArea);
     }
 </script>
 

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -44,18 +44,19 @@ class Clipboard {
         return text;
     }
 
+    copyForIE(e: Event) {
+        console.log('copyForIE event is called!', e);
+        let text = window.getSelection().toString();
+        this.elClipboard.innerText = text;
+        this.__selectElementContents__(this.elClipboard);
+        this.elClipboard.focus();
+    }
+
     pasteForIE() {
         console.log('pasteForIE event is called!');
         this.elClipboard.innerText = '';
         this.elClipboard.focus();
-    }
-
-    copyForIE() {
-        console.log('copyForIE event is called!');
-        const text = window.getSelection().toString();
-        this.elClipboard.innerText = text;
-        this.__selectElementContents__(this.elClipboard);
-        this.elClipboard.focus();
+        return this.elClipboard.innerText;
     }
 
     __bindEvent__() {
@@ -74,7 +75,9 @@ class Clipboard {
     __createClipboardElement__() {
         const elClipboard = document.createElement('div');
         elClipboard.contentEditable = 'true';
-        document.body.append(elClipboard);
+        elClipboard.id = 'clipboard';
+        elClipboard.style.cssText = "width: 200px; height: 100px; border: solid 1px orange";
+        document.body.appendChild(elClipboard);
 
         this.elClipboard = elClipboard;
     }

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -19,6 +19,7 @@ class Clipboard {
     init() {
         this.__checkBrowser__();
         this.__createClipboardElement__();
+        this.__addEventListener__();
     }
 
     copy(e: any) {
@@ -41,6 +42,12 @@ class Clipboard {
         console.log('paste event is called!');
         this.elClipboard.innerText = e.clipboardData.getData('text');
         return e.clipboardData.getData('text');
+    }
+
+    __addEventListener__() {
+        this.elClipboard.addEventListener('copy', this.copy);
+
+        this.elClipboard.addEventListener('paste', this.paste);
     }
 
     /**

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -5,8 +5,8 @@ class Clipboard {
         isIE11: boolean,
     };
     elClipboard: any;
-    targetElement: HTMLElement;
-    constructor(targetElement: HTMLElement) {
+    targetElement: HTMLTextAreaElement;
+    constructor(targetElement: HTMLTextAreaElement) {
         this.targetElement = targetElement;
         this.browser = {
             isChrome: false,
@@ -33,29 +33,37 @@ class Clipboard {
 
     }
 
-    paste(e: any) {
+    /**
+     * get Data from clipboardData from event.
+     * @param {ClipboardEvent} e
+     * @returns {String} text
+     */
+    paste(e: ClipboardEvent) {
         console.log('paste event is called!');
-        let text = '';
-        if (this.browser.isChrome) { // clipboardData에 접근 가능 할 때.
-            this.elClipboard.innerText = e.clipboardData.getData('text'); // 임시코드
-            text = e.clipboardData.getData('text');
-        }
+        this.elClipboard.innerText = e.clipboardData.getData('text'); // 임시코드
+        let text = e.clipboardData.getData('text');
         return text;
     }
 
-    copyForIE(e: Event) {
-        console.log('copyForIE event is called!', e);
-        let text = window.getSelection().toString();
+    copyForIE() {
+        console.log('copyForIE event is called!');
+        const selectionStart = this.targetElement.selectionStart;
+        const selectionEnd = this.targetElement.selectionEnd;
+        const text = this.targetElement.value.slice(selectionStart, selectionEnd)
         this.elClipboard.innerText = text;
         this.__selectElementContents__(this.elClipboard);
         this.elClipboard.focus();
     }
 
+    /**
+     * get Data from clipboardData.
+     * beforepaste event trigger to paste event. 
+     * @returns {String} text
+     */
     pasteForIE() {
         console.log('pasteForIE event is called!');
         this.elClipboard.innerText = '';
         this.elClipboard.focus();
-        this.targetElement.focus();
         return this.elClipboard.innerText;
     }
 

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -26,12 +26,11 @@ class Clipboard {
     copy(e: any) {
         console.log('copy event is called!');
         const text = window.getSelection().toString();
-        if (this.browser.isChrome) { // clipboardData에 접근 가능 할 때.
-            e.clipboardData.setData('text/plain', text);
-            e.clipboardData.setData('text/html', text);
-            this.elClipboard.innerText = text;
-            console.log(this.elClipboard.innerText);
-        }
+        e.clipboardData.setData('text/plain', text);
+        e.clipboardData.setData('text/html', text);
+        this.elClipboard.innerText = text;
+        console.log(this.elClipboard.innerText);
+
     }
 
     paste(e: any) {
@@ -56,9 +55,13 @@ class Clipboard {
         console.log('pasteForIE event is called!');
         this.elClipboard.innerText = '';
         this.elClipboard.focus();
+        this.targetElement.focus();
         return this.elClipboard.innerText;
     }
 
+    /**
+     * bind 'copy', 'paste', 'beforecopy', 'beforepaste' event To Target.
+     */
     __bindEvent__() {
         if (this.browser.isChrome) {
             this.targetElement.addEventListener('copy', this.copy.bind(this));
@@ -94,6 +97,9 @@ class Clipboard {
         };
     }
 
+    /**
+     * select Element target Element.
+     */
     __selectElementContents__(el: HTMLElement) {
         const range = document.createRange();
         range.selectNodeContents(el);


### PR DESCRIPTION
### 이슈 내용
IE에서 브라우저 이벤트 처리를 위해 copy, paste이벤트 처리시작 
README.md에 beforeCopy, Paste등록 예제 작성.
### 해결 방법
클립보드를 적용할 HTMLElement에 beforeCopy와 beforePaste이벤트를 적용한 뒤에, 
커스텀 클립보드에 copy, paste이벤트를 등록하여 처리.
* resolved #12
