### PR TITLE
Dev/content editable

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,7 @@
 </head>
 
 <body onload=initCB();>
-    <textarea contenteditable=true id="textArea"
-        style="width: 200px; height: 100px; border: solid 1px black"></textarea>
+    <textarea id="textArea" style="width: 200px; height: 100px; border: solid 1px black"></textarea>
 </body>
 <script>
     function initCB() {

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -5,8 +5,8 @@ class Clipboard {
         isIE11: boolean,
     };
     elClipboard: any;
-    targetElement: HTMLTextAreaElement;
-    constructor(targetElement: HTMLTextAreaElement) {
+    targetElement: any;
+    constructor(targetElement: any) {
         this.targetElement = targetElement;
         this.browser = {
             isChrome: false,

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -47,9 +47,16 @@ class Clipboard {
 
     copyForIE() {
         console.log('copyForIE event is called!');
-        const selectionStart = this.targetElement.selectionStart;
-        const selectionEnd = this.targetElement.selectionEnd;
-        const text = this.targetElement.value.slice(selectionStart, selectionEnd)
+        const isContentEditable = this.targetElement.contentEditable;
+        const isTextArea = this.targetElement.tagName === 'TEXTAREA';
+        let text;
+        if (isContentEditable) {
+            text = window.getSelection().toString();
+        } else if (isTextArea) {
+            const selectionStart = this.targetElement.selectionStart;
+            const selectionEnd = this.targetElement.selectionEnd;
+            text = this.targetElement.value.slice(selectionStart, selectionEnd)
+        }
         this.elClipboard.innerText = text;
         this.__selectElementContents__(this.elClipboard);
         this.elClipboard.focus();


### PR DESCRIPTION
### 이슈 내용
textArea와 contenteditable일 때 둘다 처리하도록 처리.
### 해결 방법
textArea는 text의 selectionStart,End를 이용하고, contentEditable window getSelection이용하여처리.
* resolved #15 
