### PR TITLE
:fire: IE TextArea 복사 안됨.

### DIFF
--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -50,12 +50,14 @@ class Clipboard {
         const isContentEditable = this.targetElement.contentEditable;
         const isTextArea = this.targetElement.tagName === 'TEXTAREA';
         let text;
-        if (isContentEditable) {
-            text = window.getSelection().toString();
-        } else if (isTextArea) {
+        if (isTextArea) {
+            console.log('textArea!');
             const selectionStart = this.targetElement.selectionStart;
             const selectionEnd = this.targetElement.selectionEnd;
             text = this.targetElement.value.slice(selectionStart, selectionEnd)
+        } else if (isContentEditable) {
+            console.log('contentEditable!');
+            text = window.getSelection().toString();
         }
         this.elClipboard.innerText = text;
         this.__selectElementContents__(this.elClipboard);


### PR DESCRIPTION
### 이슈 내용
contentEditable과 tagName이 TEXTAREA일 때 분기를 나눴는데,
textArea도 contentEditable이어서 window.getSelection에서 데이터를 못가져왔음.
### 해결 방법
조건문 순서를 바꾸는걸로 처리. (.. 다른 조건이 더 나아보이긴함.. )
* resolved #17 
